### PR TITLE
fix: remove optional create PR pattern input for consistency in commit message validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,9 @@ inputs:
     description: "GitHub token for API access"
     required: true
     default: ${{ github.token }}
-  pattern:
-    description: "Regex pattern for commit message validation"
-    required: false
-    default: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(\w+\))?: .+$'
 runs:
   using: "node20"
   main: "dist/index.js"
 branding:
   icon: "check-circle"
   color: "green"
-

--- a/commit-message-validator.js
+++ b/commit-message-validator.js
@@ -8,7 +8,7 @@ async function run() {
 
     const mergeBranchPattern = 'Merge branch [\'"][^\'"]+[\'"] into [^\\s]+';
     const revertPattern = 'Revert ".*"';
-    const createPrPattern = core.getInput('create-pr-pattern') || 'Create PR for #\\d+';
+    const createPrPattern = 'Create PR for #\\d+';
     const types = [
       'feat', 'fix', 'chore', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'revert'
     ].join('|');


### PR DESCRIPTION
This pull request simplifies the configuration of commit message validation by removing the ability to customize the regex pattern through the GitHub Action's inputs. The validation logic now relies on a fixed set of patterns within the code.

**Configuration simplification:**

* Removed the `pattern` input from `action.yml`, so users can no longer specify a custom regex for commit message validation.

**Validation logic update:**

* Updated `commit-message-validator.js` to use a hardcoded `createPrPattern` instead of reading it from action inputs, ensuring consistent validation behavior.